### PR TITLE
TFC金属板与Create金属板修复和安山合金锌锭合成修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 .vscode/
 .trae/
 
-# jsconfig.json files (VS Code configuration)
+# IDE configuration files
 **/jsconfig.json
+config/probe-settings.json
 
 # OS files
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# IDE files
+.vscode/
+.trae/
+
+# jsconfig.json files (VS Code configuration)
+**/jsconfig.json
+
+# OS files
+Thumbs.db
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ config/probe-settings.json
 # OS files
 Thumbs.db
 .DS_Store
+
+# Change log
+change log/

--- a/config/probe-settings.json
+++ b/config/probe-settings.json
@@ -1,6 +1,0 @@
-{
-    "probejs.classScanning": false,
-    "probejs.complete": true,
-    "probejs.modHash": 8171026966545008014,
-    "probejs.generateBeans": true
-}

--- a/config/probe-settings.json
+++ b/config/probe-settings.json
@@ -1,0 +1,6 @@
+{
+    "probejs.classScanning": false,
+    "probejs.complete": true,
+    "probejs.modHash": 8171026966545008014,
+    "probejs.generateBeans": true
+}

--- a/server_scripts/cbc_melting.js
+++ b/server_scripts/cbc_melting.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-    let recipeCounter = 0
+    let recipeCounter = 0 // 提示配方ID重复，所以额外加入计数器来防止配方ID重复
     
     event.forEachRecipe({ type: 'tfc:heating' }, recipe => {
         const json = recipe.json

--- a/server_scripts/cbc_melting.js
+++ b/server_scripts/cbc_melting.js
@@ -1,4 +1,6 @@
 ServerEvents.recipes(event => {
+    let recipeCounter = 0
+    
     event.forEachRecipe({ type: 'tfc:heating' }, recipe => {
         const json = recipe.json
         if (!json.has('result_fluid')) return
@@ -28,6 +30,35 @@ ServerEvents.recipes(event => {
         // 斜率: (600-400) / (1500-1080) ≈ 0.476 tick/°C
         const processingTime = Math.round(400 + (temperature - 1080) * (200 / 420))
         
+        // 生成唯一的配方 ID
+        const inputKey = ingredientArray.map(ing => {
+            if (ing.item) {
+                return `item/${ing.item.replace(':', '/')}`
+            }
+            if (ing.tag) {
+                return `tag/${ing.tag.replace(':', '/')}`
+            }
+            return 'unknown'
+        }).join('_')
+        
+        const fluidId = resultFluid.get('id').getAsString().replace(':', '/')
+        const recipeId = `kubejs:createbigcannons/melting/${fluidId}/${inputKey}_${recipeCounter++}`
+        
+        // =====================================================================
+        // 机械动力冲压板与TFC锻造薄板修复
+        // 替换标签，确保只使用TFC锻造板而不混用Create冲压板
+        // =====================================================================
+        // 替换c:sheets/*标签为kubejs:tfc_single_sheets/*
+        // 替换c:double_sheets/*标签为kubejs:tfc_double_sheets/*
+        ingredientArray.forEach(ing => {
+            if (ing.tag) {
+                if (ing.tag.startsWith('c:sheets/')) {
+                    ing.tag = ing.tag.replace('c:sheets/', 'kubejs:tfc_single_sheets/')
+                } else if (ing.tag.startsWith('c:double_sheets/')) {
+                    ing.tag = ing.tag.replace('c:double_sheets/', 'kubejs:tfc_double_sheets/')
+                }
+            }
+        })
         event.custom({
             type: 'createbigcannons:melting',
             heat_requirement: heatRequirement,
@@ -37,6 +68,6 @@ ServerEvents.recipes(event => {
                 amount: resultFluid.get('amount').getAsInt(),
                 id: resultFluid.get('id').getAsString()
             }]
-        })
+        }).id(recipeId)
     })
 })

--- a/server_scripts/event_recipes.js
+++ b/server_scripts/event_recipes.js
@@ -59,12 +59,18 @@ ServerEvents.recipes(event => {
       'createdieselgenerators:wire_cutters'
     ]
   )
-  event.shapeless(Item.of('create:andesite_alloy', 8),
-    [
+  // 安山合金配方 - 支持铁锭和锌锭两种材料
+  // 配方1：铁锭版本
+  event.shapeless(Item.of('create:andesite_alloy', 8), [
       '#c:cobblestones',
       '#c:ingots/iron'
-    ]
-  )
+  ]).id('kubejs:create/andesite_alloy_iron')
+
+  // 配方2：锌锭版本
+  event.shapeless(Item.of('create:andesite_alloy', 8), [
+      '#c:cobblestones',
+      '#c:ingots/zinc'
+  ]).id('kubejs:create/andesite_alloy_zinc')
 
   //metal
   event.replaceInput(
@@ -119,10 +125,13 @@ ServerEvents.recipes(event => {
     'minecraft:iron_nugget',
     1500
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 10))
+  .id('kubejs:tfc/heating/iron_nugget_to_cast_iron')
+
   event.recipes.tfc.heating(
     'minecraft:iron_block',
     1500
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))
+  .id('kubejs:tfc/heating/iron_block_to_cast_iron')
 
 
   event.replaceInput(

--- a/server_scripts/event_recipes.js
+++ b/server_scripts/event_recipes.js
@@ -125,13 +125,13 @@ ServerEvents.recipes(event => {
     'minecraft:iron_nugget',
     1500
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 10))
-  .id('kubejs:tfc/heating/iron_nugget_to_cast_iron')
+  .id('kubejs:tfc/heating/tfc/metal/cast_iron/minecraft/iron_nugget')
 
   event.recipes.tfc.heating(
     'minecraft:iron_block',
     1500
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))
-  .id('kubejs:tfc/heating/iron_block_to_cast_iron')
+  .id('kubejs:tfc/heating/tfc/metal/cast_iron/minecraft/iron_block')
 
 
   event.replaceInput(

--- a/server_scripts/stamped_sheets_fix.js
+++ b/server_scripts/stamped_sheets_fix.js
@@ -189,10 +189,10 @@ ServerEvents.recipes(event => {
                 ]
             )
             
-            if (data.temperature < 1080) {
-                compactingRecipe.heated()
-            } else {
+            if (data.temperature > 1080) {
                 compactingRecipe.superheated()
+            } else {
+                compactingRecipe.heated()
             }
             compactingRecipe.id(plateToSheetCompactingRecipeId)
             

--- a/server_scripts/stamped_sheets_fix.js
+++ b/server_scripts/stamped_sheets_fix.js
@@ -14,9 +14,9 @@
 //   5. 添加冲压板与TFC锻造板的双向转换配方
 // =============================================================================
 
-// 全局变量：存储扫描到的TFC板材物品ID
-const singleSheetsMetalList = []  // TFC单层锻造板（tfc:metal/sheet/*）
-const doubleSheetsMetalList = []  // TFC双层锻造板（tfc:metal/double_sheet/*）
+// =============================================================================
+// 配置数据区域 - 方便修改和调试
+// =============================================================================
 
 // 其他模组冲压板映射表
 // 用途：建立Create等模组的冲压板与TFC锻造板的对应关系
@@ -29,6 +29,18 @@ const otherModPlateMap = {
     'c:plates/brass':           {'item':'create:brass_sheet','temperature':940},
     'c:plates/zinc':            {'item':'createdeco:zinc_sheet','temperature':419}
 }
+
+// TFC及其附属模组列表
+// 这些模组的配方如果使用了c:sheets/*标签，都需要替换
+const tfcMods = ['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']
+
+// =============================================================================
+// 脚本主体
+// =============================================================================
+
+// 全局变量：存储扫描到的TFC板材物品ID
+const singleSheetsMetalList = []  // TFC单层锻造板（tfc:metal/sheet/*）
+const doubleSheetsMetalList = []  // TFC双层锻造板（tfc:metal/double_sheet/*）
 
 // 主映射表：所有板材关系的核心数据
 // 键：公共标签（如 c:sheets/copper, c:plates/copper, c:double_sheets/copper）
@@ -138,10 +150,8 @@ ServerEvents.recipes(event => {
     // 部分1: 替换TFC相关模组配方中的标签引用
     // 目的：让TFC及其附属模组的配方只能使用TFC锻造板，不能使用Create冲压板
     // =========================================================================
-    // TFC及其附属模组列表
+    // 使用从配置文件导入的 tfcMods 列表
     // 这些模组的配方如果使用了c:sheets/*标签，都需要替换
-    const tfcMods = ['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']
-    
     tfcMods.forEach(mod => {
         // 替换单层板标签
         // 将配方输入中的 #c:sheets/<metal> 替换为 #kubejs:tfc_single_sheets/<metal>

--- a/server_scripts/stamped_sheets_fix.js
+++ b/server_scripts/stamped_sheets_fix.js
@@ -146,19 +146,20 @@ ServerEvents.recipes(event => {
     Object.entries(sheetsItemMap).forEach(([tag, data]) => {
         // 只处理有对应冲压板的金属
         if (data.sheetItemID && data.temperature) {
-            const safeSheetItemID = data.sheetItemID.replace(':', '_')
+            const safeSheetItemID = data.sheetItemID.replace(':', '/')
+            const safeFluidID = data.fluidID.replace(':', '/')
             
             // =====================================================================
             // 1. 冲压板熔化配方
             // =====================================================================
             // 1.1 TFC加热配方：冲压板 -> 对应金属液(100mB)
-            const tfcHeatingRecipeId = `kubejs:tfc/heating/${safeSheetItemID}`
+            const tfcHeatingRecipeId = `kubejs:tfc/heating/${safeFluidID}/${safeSheetItemID}`
             event.recipes.tfc.heating(data.sheetItemID, data.temperature)
                 .fluidOutput(Fluid.of(data.fluidID, data.fluidAmount))
                 .id(tfcHeatingRecipeId)
             
             // 1.2 Create Big Cannons熔化配方
-            const cbcMeltingRecipeId = `kubejs:createbigcannons/melting/${safeSheetItemID}`
+            const cbcMeltingRecipeId = `kubejs:createbigcannons/melting/${safeFluidID}/${safeSheetItemID}`
             const cbcHeatRequirement = data.temperature > 1080 ? 'superheated' : 'heated'
             const processingTime = Math.round(400 + (data.temperature - 1080) * (200 / 420))
             const ingredientArray = [{tag: data.tagID}]
@@ -178,7 +179,8 @@ ServerEvents.recipes(event => {
             // 2. 冲压板与锻造板双向转换
             // =====================================================================
             // 2.1 塑形配方：2个冲压板 + 助焊剂 -> TFC锻造板
-            const plateToSheetCompactingRecipeId = `kubejs:create/compacting/${safeSheetItemID}`
+            const safeTfcItemID = data.tfcItemID.replace(':', '/')
+            const plateToSheetCompactingRecipeId = `kubejs:create/compacting/${safeTfcItemID}/${safeSheetItemID}`
             const compactingRecipe = event.recipes.create.compacting(
                 data.tfcItemID,
                 [
@@ -195,7 +197,7 @@ ServerEvents.recipes(event => {
             compactingRecipe.id(plateToSheetCompactingRecipeId)
             
             // 2.2 切削配方：TFC锻造板 -> 2个冲压板（不返还助焊剂）
-            const sheetToPlateCuttingRecipeId = `kubejs:create/cutting/${safeSheetItemID}`
+            const sheetToPlateCuttingRecipeId = `kubejs:create/cutting/${safeSheetItemID}/${safeTfcItemID}`
             event.recipes.create.cutting(`2x ${data.sheetItemID}`, `${data.tfcItemID}`)
                 .id(sheetToPlateCuttingRecipeId)
         }

--- a/server_scripts/stamped_sheets_fix.js
+++ b/server_scripts/stamped_sheets_fix.js
@@ -1,19 +1,27 @@
 // =============================================================================
 // 机械动力冲压板与TFC锻造薄板修复脚本
 // =============================================================================
-// 问题：Create冲压板与TFC锻造薄板使用相同的c:sheets标签，导致经济不平衡
+// 问题：
+//   - Create冲压板（sheet）与TFC锻造薄板共用 c:sheets/<金属> 标签
+//   - 导致TFC配方可以误用Create冲压板，造成经济不平衡
+//   - 需要将两者在标签层面分离，同时保留合理的转换途径
+//
 // 解决方案：
-//   1. 创建独立的kubejs标签专门供TFC相关配方使用
-//   2. 替换TFC及其附属模组配方中的标签引用
-//   3. 添加冲压板的独立加热配方和双向转换配方
+//   1. 扫描所有物品，收集TFC单层/双层锻造板
+//   2. 为每种金属创建独立的kubejs标签（仅包含TFC锻造板）
+//   3. 替换TFC及其附属模组配方中的标签引用，使其只使用TFC板
+//   4. 为Create冲压板添加独立的加热熔化配方
+//   5. 添加冲压板与TFC锻造板的双向转换配方
 // =============================================================================
 
-// 全局变量
-const singleSheetsMetalList = []  // TFC单层板物品列表
-const doubleSheetsMetalList = []  // TFC双层板物品列表
+// 全局变量：存储扫描到的TFC板材物品ID
+const singleSheetsMetalList = []  // TFC单层锻造板（tfc:metal/sheet/*）
+const doubleSheetsMetalList = []  // TFC双层锻造板（tfc:metal/double_sheet/*）
 
-// 其他模组冲压板映射（用于建立与TFC锻造板的关系）
-// 格式: c:plates/<材料> -> {item: 冲压板物品ID, temperature: 熔化温度}
+// 其他模组冲压板映射表
+// 用途：建立Create等模组的冲压板与TFC锻造板的对应关系
+// 格式: c:plates/<材料> -> {item: 冲压板物品ID, temperature: 熔化温度(摄氏度)}
+// 注意：这里的温度用于判断加热级别和熔化配方
 const otherModPlateMap = {
     'c:plates/copper':          {'item':'create:copper_sheet','temperature':1080},
     'c:plates/wrought_iron':    {'item':'create:iron_sheet','temperature':1538},
@@ -23,21 +31,23 @@ const otherModPlateMap = {
 }
 
 // 主映射表：所有板材关系的核心数据
-// 格式: tag -> {
-//   tfcItemID: TFC锻造板物品ID,
-//   sheetItemID: 对应其他模组冲压板物品ID,
-//   fluidID: 熔化后产出流体ID,
-//   fluidAmount: 熔化后产出流体数量,
-//   temperature: 熔化温度,
-//   tagID: 使用的材料标签ID
-// }
+// 键：公共标签（如 c:sheets/copper, c:plates/copper, c:double_sheets/copper）
+// 值：包含以下字段的对象
+//   - tfcItemID:    对应的TFC锻造板物品ID
+//   - sheetItemID:  对应的其他模组冲压板物品ID（如create:copper_sheet）
+//   - fluidID:      熔化后产出的流体ID（如tfc:metal/copper）
+//   - fluidAmount:  熔化后产出的流体数量（单层100mB，双层200mB）
+//   - temperature:  熔化温度（摄氏度）
+//   - tagID:        用于配方输入的材料标签ID
 const sheetsItemMap = {}
 
 // =============================================================================
-// 标签事件：建立独立的TFC板材标签
+// 标签事件：扫描物品并建立独立的TFC板材标签
+// 执行时机：服务器启动时，用于注册自定义物品标签
 // =============================================================================
 ServerEvents.tags('item', event => {
-    // 步骤1: 扫描所有物品，收集TFC锻造板
+    // 步骤1: 扫描所有注册的物品，收集TFC锻造板
+    // 通过检查物品ID前缀来区分单层板和双层板
     Item.getList().forEach(item => {
         const id = item.id.toString()
         if (id.startsWith('tfc:metal/sheet/')) {
@@ -48,30 +58,38 @@ ServerEvents.tags('item', event => {
     })
 
     // 步骤2: 处理单层锻造板
+    // 为每种金属创建kubejs:tfc_single_sheets/<metal>标签，并填充sheetsItemMap
     singleSheetsMetalList.forEach(itemID => {
+        // 从物品ID中提取金属类型（如 'copper', 'iron', 'wrought_iron'）
         const metalType = itemID.split('/')[2]
         
-        // 创建独立标签 kubejs:tfc_single_sheets/<材料>，仅包含TFC锻造板
+        // 创建独立标签，仅包含TFC锻造板，不包含Create冲压板
         event.add(`kubejs:tfc_single_sheets/${metalType}`, itemID)
         
-        // 构建相关的公共标签映射
+        // 构建相关的公共标签列表（c:sheets和c:plates都指向同一映射）
+        // 这样无论配方使用哪种标签，都能正确关联到TFC物品
         const publicTags = [`c:sheets/${metalType}`,`c:plates/${metalType}`]
         publicTags.forEach(tag => {
+            // 延迟初始化：如果映射不存在则创建空对象
             if (!sheetsItemMap[tag]) sheetsItemMap[tag] = {}
             
+            // 记录TFC锻造板物品ID
             sheetsItemMap[tag].tfcItemID = itemID
-            sheetsItemMap[tag].fluidAmount = 100  // 单层板熔化产出100mB
+            // 单层板熔化产出100mB流体（TFC标准）
+            sheetsItemMap[tag].fluidAmount = 100
             
-            // 锻铁板特殊处理：加热产出铸铁液而非铁液
+            // 特殊处理：锻铁（wrought_iron）加热后产出铸铁液而非铁液
+            // 这是TFC的冶金机制：锻铁是熟铁，加热后渗碳变成铸铁
             if (metalType == 'wrought_iron') {
                 sheetsItemMap[tag].fluidID = `tfc:metal/cast_iron`
+                // 标签中的wrought_iron替换为iron，因为流体是cast_iron
                 sheetsItemMap[tag].tagID = tag.replace('wrought_iron','iron')
             } else {
                 sheetsItemMap[tag].fluidID = `tfc:metal/${metalType}`
                 sheetsItemMap[tag].tagID = tag
             }
             
-            // 如果有对应的其他模组冲压板，加入映射
+            // 如果有对应的其他模组冲压板（如Create），加入映射关系
             if (otherModPlateMap[tag]) {
                 sheetsItemMap[tag].sheetItemID = otherModPlateMap[tag].item
                 sheetsItemMap[tag].temperature = otherModPlateMap[tag].temperature
@@ -79,19 +97,21 @@ ServerEvents.tags('item', event => {
         })
     })
 
-    // 步骤3: 处理双层锻造板
+    // 步骤3: 处理双层锻造板（逻辑与单层板类似，但流体数量翻倍）
     doubleSheetsMetalList.forEach(itemID => {
         const metalType = itemID.split('/')[2]
         
-        // 创建独立标签 kubejs:tfc_double_sheets/<材料>
+        // 创建双层板的独立标签
         event.add(`kubejs:tfc_double_sheets/${metalType}`, itemID)
         
+        // 双层板对应的公共标签
         const publicTags = [`c:double_sheets/${metalType}`,`c:double_plates/${metalType}`]
         publicTags.forEach(tag => {
             if (!sheetsItemMap[tag]) sheetsItemMap[tag] = {}
             
             sheetsItemMap[tag].tfcItemID = itemID
-            sheetsItemMap[tag].fluidAmount = 200  // 双层板熔化产出200mB
+            // 双层板熔化产出200mB流体（是单层板的两倍）
+            sheetsItemMap[tag].fluidAmount = 200
             
             if (metalType == 'wrought_iron') {
                 sheetsItemMap[tag].fluidID = `tfc:metal/cast_iron`
@@ -110,26 +130,32 @@ ServerEvents.tags('item', event => {
 })
 
 // =============================================================================
-// 配方事件：替换标签并添加新配方
+// 配方事件：替换标签引用并添加新配方
+// 执行时机：服务器启动时，用于修改和注册配方
 // =============================================================================
 ServerEvents.recipes(event => {
     // =========================================================================
     // 部分1: 替换TFC相关模组配方中的标签引用
+    // 目的：让TFC及其附属模组的配方只能使用TFC锻造板，不能使用Create冲压板
     // =========================================================================
+    // TFC及其附属模组列表
+    // 这些模组的配方如果使用了c:sheets/*标签，都需要替换
     const tfcMods = ['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']
     
     tfcMods.forEach(mod => {
-        // 替换单层板标签：c:sheets/* -> kubejs:tfc_single_sheets/*
+        // 替换单层板标签
+        // 将配方输入中的 #c:sheets/<metal> 替换为 #kubejs:tfc_single_sheets/<metal>
+        // 这样TFC配方只会消耗TFC锻造板，不会误消耗Create冲压板
         singleSheetsMetalList.forEach(itemID => {
             const metalType = itemID.split('/')[2]
             event.replaceInput(
-                {mod: mod},
-                `#c:sheets/${metalType}`,
-                `#kubejs:tfc_single_sheets/${metalType}`
+                {mod: mod},                          // 只替换指定模组的配方
+                `#c:sheets/${metalType}`,            // 原标签（包含Create冲压板）
+                `#kubejs:tfc_single_sheets/${metalType}`  // 新标签（仅TFC板）
             )
         })
         
-        // 替换双层板标签：c:double_sheets/* -> kubejs:tfc_double_sheets/*
+        // 替换双层板标签（逻辑同上）
         doubleSheetsMetalList.forEach(itemID => {
             const metalType = itemID.split('/')[2]
             event.replaceInput(
@@ -141,26 +167,35 @@ ServerEvents.recipes(event => {
     })
 
     // =========================================================================
-    // 部分2: 为每个冲压板添加配方
+    // 部分2: 为每个冲压板添加新配方
+    // 包括：熔化配方、与TFC板的双向转换配方
     // =========================================================================
     Object.entries(sheetsItemMap).forEach(([tag, data]) => {
-        // 只处理有对应冲压板的金属
+        // 只处理有对应冲压板的金属（如铜、铁、金、黄铜、锌）
+        // 如果sheetItemID或temperature不存在，说明该金属没有对应的冲压板
         if (data.sheetItemID && data.temperature) {
+            // 将物品ID中的冒号替换为斜杠，用于构建安全的配方ID（避免ID冲突）
             const safeSheetItemID = data.sheetItemID.replace(':', '/')
             const safeFluidID = data.fluidID.replace(':', '/')
             
             // =====================================================================
             // 1. 冲压板熔化配方
+            // 用途：让冲压板可以通过加热变成金属液，与TFC机制保持一致
             // =====================================================================
-            // 1.1 TFC加热配方：冲压板 -> 对应金属液(100mB)
+            // 1.1 TFC加热配方：冲压板 -> 对应金属液
+            // 将冲压板放在TFC加热设备上，达到指定温度后熔化成液体
             const tfcHeatingRecipeId = `kubejs:tfc/heating/${safeFluidID}/${safeSheetItemID}`
             event.recipes.tfc.heating(data.sheetItemID, data.temperature)
                 .fluidOutput(Fluid.of(data.fluidID, data.fluidAmount))
                 .id(tfcHeatingRecipeId)
             
             // 1.2 Create Big Cannons熔化配方
+            // 如果安装了CBC模组，冲压板也可以在CBC的熔炉中熔化
             const cbcMeltingRecipeId = `kubejs:createbigcannons/melting/${safeFluidID}/${safeSheetItemID}`
+            // 温度>1080°C需要超高温（superheated），否则普通加热（heated）
             const cbcHeatRequirement = data.temperature > 1080 ? 'superheated' : 'heated'
+            // 处理时间：基础400tick + 温度差 * 系数
+            // 温度越高，熔化时间越长（1080°C=400tick, 1500°C≈600tick）
             const processingTime = Math.round(400 + (data.temperature - 1080) * (200 / 420))
             const ingredientArray = [{tag: data.tagID}]
             
@@ -176,27 +211,32 @@ ServerEvents.recipes(event => {
             }).id(cbcMeltingRecipeId)
 
             // =====================================================================
-            // 2. 冲压板与锻造板双向转换
+            // 2. 冲压板与TFC锻造板的双向转换配方
+            // 目的：允许玩家在两种板材之间转换，但需要付出一定代价（助焊剂）
             // =====================================================================
-            // 2.1 塑形配方：2个冲压板 + 助焊剂 -> TFC锻造板
+            // 2.1 塑形配方：2个冲压板 + 助焊剂 -> 1个TFC锻造板
+            // 模拟金属加工：冲压板通过加热和助焊剂焊接成锻造板
             const safeTfcItemID = data.tfcItemID.replace(':', '/')
             const plateToSheetCompactingRecipeId = `kubejs:create/compacting/${safeTfcItemID}/${safeSheetItemID}`
             const compactingRecipe = event.recipes.create.compacting(
-                data.tfcItemID,
+                data.tfcItemID,  // 输出：TFC锻造板
                 [
-                    Ingredient.of(`#${data.tagID}`, 2),
-                    Ingredient.of(`tfc:powder/flux`)
+                    Ingredient.of(`#${data.tagID}`, 2),  // 输入：2个冲压板（使用标签，兼容其他模组）
+                    Ingredient.of(`tfc:powder/flux`)      // 消耗：助焊剂（增加成本）
                 ]
             )
             
+            // 根据金属熔点选择加热级别
             if (data.temperature > 1080) {
-                compactingRecipe.superheated()
+                compactingRecipe.superheated()  // 高熔点金属需要超高温
             } else {
-                compactingRecipe.heated()
+                compactingRecipe.heated()       // 低熔点金属只需普通加热
             }
             compactingRecipe.id(plateToSheetCompactingRecipeId)
             
-            // 2.2 切削配方：TFC锻造板 -> 2个冲压板（不返还助焊剂）
+            // 2.2 切削配方：1个TFC锻造板 -> 2个冲压板
+            // 模拟金属加工：锻造板可以通过机械切割成两个冲压板
+            // 注意：不返还助焊剂，所以逆向转换是有损耗的
             const sheetToPlateCuttingRecipeId = `kubejs:create/cutting/${safeSheetItemID}/${safeTfcItemID}`
             event.recipes.create.cutting(`2x ${data.sheetItemID}`, `${data.tfcItemID}`)
                 .id(sheetToPlateCuttingRecipeId)

--- a/server_scripts/stamped_sheets_fix.js
+++ b/server_scripts/stamped_sheets_fix.js
@@ -1,0 +1,203 @@
+// =============================================================================
+// 机械动力冲压板与TFC锻造薄板修复脚本
+// =============================================================================
+// 问题：Create冲压板与TFC锻造薄板使用相同的c:sheets标签，导致经济不平衡
+// 解决方案：
+//   1. 创建独立的kubejs标签专门供TFC相关配方使用
+//   2. 替换TFC及其附属模组配方中的标签引用
+//   3. 添加冲压板的独立加热配方和双向转换配方
+// =============================================================================
+
+// 全局变量
+const singleSheetsMetalList = []  // TFC单层板物品列表
+const doubleSheetsMetalList = []  // TFC双层板物品列表
+
+// 其他模组冲压板映射（用于建立与TFC锻造板的关系）
+// 格式: c:plates/<材料> -> {item: 冲压板物品ID, temperature: 熔化温度}
+const otherModPlateMap = {
+    'c:plates/copper':          {'item':'create:copper_sheet','temperature':1080},
+    'c:plates/wrought_iron':    {'item':'create:iron_sheet','temperature':1538},
+    'c:plates/gold':            {'item':'create:golden_sheet','temperature':1064},
+    'c:plates/brass':           {'item':'create:brass_sheet','temperature':940},
+    'c:plates/zinc':            {'item':'createdeco:zinc_sheet','temperature':419}
+}
+
+// 主映射表：所有板材关系的核心数据
+// 格式: tag -> {
+//   tfcItemID: TFC锻造板物品ID,
+//   sheetItemID: 对应其他模组冲压板物品ID,
+//   fluidID: 熔化后产出流体ID,
+//   fluidAmount: 熔化后产出流体数量,
+//   temperature: 熔化温度,
+//   tagID: 使用的材料标签ID
+// }
+const sheetsItemMap = {}
+
+// =============================================================================
+// 标签事件：建立独立的TFC板材标签
+// =============================================================================
+ServerEvents.tags('item', event => {
+    // 步骤1: 扫描所有物品，收集TFC锻造板
+    Item.getList().forEach(item => {
+        const id = item.id.toString()
+        if (id.startsWith('tfc:metal/sheet/')) {
+            singleSheetsMetalList.push(id)
+        } else if (id.startsWith('tfc:metal/double_sheet/')) {
+            doubleSheetsMetalList.push(id)
+        }
+    })
+
+    // 步骤2: 处理单层锻造板
+    singleSheetsMetalList.forEach(itemID => {
+        const metalType = itemID.split('/')[2]
+        
+        // 创建独立标签 kubejs:tfc_single_sheets/<材料>，仅包含TFC锻造板
+        event.add(`kubejs:tfc_single_sheets/${metalType}`, itemID)
+        
+        // 构建相关的公共标签映射
+        const publicTags = [`c:sheets/${metalType}`,`c:plates/${metalType}`]
+        publicTags.forEach(tag => {
+            if (!sheetsItemMap[tag]) sheetsItemMap[tag] = {}
+            
+            sheetsItemMap[tag].tfcItemID = itemID
+            sheetsItemMap[tag].fluidAmount = 100  // 单层板熔化产出100mB
+            
+            // 锻铁板特殊处理：加热产出铸铁液而非铁液
+            if (metalType == 'wrought_iron') {
+                sheetsItemMap[tag].fluidID = `tfc:metal/cast_iron`
+                sheetsItemMap[tag].tagID = tag.replace('wrought_iron','iron')
+            } else {
+                sheetsItemMap[tag].fluidID = `tfc:metal/${metalType}`
+                sheetsItemMap[tag].tagID = tag
+            }
+            
+            // 如果有对应的其他模组冲压板，加入映射
+            if (otherModPlateMap[tag]) {
+                sheetsItemMap[tag].sheetItemID = otherModPlateMap[tag].item
+                sheetsItemMap[tag].temperature = otherModPlateMap[tag].temperature
+            }
+        })
+    })
+
+    // 步骤3: 处理双层锻造板
+    doubleSheetsMetalList.forEach(itemID => {
+        const metalType = itemID.split('/')[2]
+        
+        // 创建独立标签 kubejs:tfc_double_sheets/<材料>
+        event.add(`kubejs:tfc_double_sheets/${metalType}`, itemID)
+        
+        const publicTags = [`c:double_sheets/${metalType}`,`c:double_plates/${metalType}`]
+        publicTags.forEach(tag => {
+            if (!sheetsItemMap[tag]) sheetsItemMap[tag] = {}
+            
+            sheetsItemMap[tag].tfcItemID = itemID
+            sheetsItemMap[tag].fluidAmount = 200  // 双层板熔化产出200mB
+            
+            if (metalType == 'wrought_iron') {
+                sheetsItemMap[tag].fluidID = `tfc:metal/cast_iron`
+                sheetsItemMap[tag].tagID = tag.replace('wrought_iron','iron')
+            } else {
+                sheetsItemMap[tag].fluidID = `tfc:metal/${metalType}`
+                sheetsItemMap[tag].tagID = tag
+            }
+            
+            if (otherModPlateMap[tag]) {
+                sheetsItemMap[tag].sheetItemID = otherModPlateMap[tag].item
+                sheetsItemMap[tag].temperature = otherModPlateMap[tag].temperature
+            }
+        })
+    })
+})
+
+// =============================================================================
+// 配方事件：替换标签并添加新配方
+// =============================================================================
+ServerEvents.recipes(event => {
+    // =========================================================================
+    // 部分1: 替换TFC相关模组配方中的标签引用
+    // =========================================================================
+    const tfcMods = ['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']
+    
+    tfcMods.forEach(mod => {
+        // 替换单层板标签：c:sheets/* -> kubejs:tfc_single_sheets/*
+        singleSheetsMetalList.forEach(itemID => {
+            const metalType = itemID.split('/')[2]
+            event.replaceInput(
+                {mod: mod},
+                `#c:sheets/${metalType}`,
+                `#kubejs:tfc_single_sheets/${metalType}`
+            )
+        })
+        
+        // 替换双层板标签：c:double_sheets/* -> kubejs:tfc_double_sheets/*
+        doubleSheetsMetalList.forEach(itemID => {
+            const metalType = itemID.split('/')[2]
+            event.replaceInput(
+                {mod: mod},
+                `#c:double_sheets/${metalType}`,
+                `#kubejs:tfc_double_sheets/${metalType}`
+            )
+        })
+    })
+
+    // =========================================================================
+    // 部分2: 为每个冲压板添加配方
+    // =========================================================================
+    Object.entries(sheetsItemMap).forEach(([tag, data]) => {
+        // 只处理有对应冲压板的金属
+        if (data.sheetItemID && data.temperature) {
+            const safeSheetItemID = data.sheetItemID.replace(':', '_')
+            
+            // =====================================================================
+            // 1. 冲压板熔化配方
+            // =====================================================================
+            // 1.1 TFC加热配方：冲压板 -> 对应金属液(100mB)
+            const tfcHeatingRecipeId = `kubejs:tfc/heating/${safeSheetItemID}`
+            event.recipes.tfc.heating(data.sheetItemID, data.temperature)
+                .fluidOutput(Fluid.of(data.fluidID, data.fluidAmount))
+                .id(tfcHeatingRecipeId)
+            
+            // 1.2 Create Big Cannons熔化配方
+            const cbcMeltingRecipeId = `kubejs:createbigcannons/melting/${safeSheetItemID}`
+            const cbcHeatRequirement = data.temperature > 1080 ? 'superheated' : 'heated'
+            const processingTime = Math.round(400 + (data.temperature - 1080) * (200 / 420))
+            const ingredientArray = [{tag: data.tagID}]
+            
+            event.custom({
+                type: 'createbigcannons:melting',
+                heat_requirement: cbcHeatRequirement,
+                ingredients: ingredientArray,
+                processing_time: processingTime,
+                results: [{
+                    amount: data.fluidAmount,
+                    id: data.fluidID
+                }]
+            }).id(cbcMeltingRecipeId)
+
+            // =====================================================================
+            // 2. 冲压板与锻造板双向转换
+            // =====================================================================
+            // 2.1 塑形配方：2个冲压板 + 助焊剂 -> TFC锻造板
+            const plateToSheetCompactingRecipeId = `kubejs:create/compacting/${safeSheetItemID}`
+            const compactingRecipe = event.recipes.create.compacting(
+                data.tfcItemID,
+                [
+                    Ingredient.of(`#${data.tagID}`, 2),
+                    Ingredient.of(`tfc:powder/flux`)
+                ]
+            )
+            
+            if (data.temperature < 1080) {
+                compactingRecipe.heated()
+            } else {
+                compactingRecipe.superheated()
+            }
+            compactingRecipe.id(plateToSheetCompactingRecipeId)
+            
+            // 2.2 切削配方：TFC锻造板 -> 2个冲压板（不返还助焊剂）
+            const sheetToPlateCuttingRecipeId = `kubejs:create/cutting/${safeSheetItemID}`
+            event.recipes.create.cutting(`2x ${data.sheetItemID}`, `${data.tfcItemID}`)
+                .id(sheetToPlateCuttingRecipeId)
+        }
+    })
+})


### PR DESCRIPTION
# 第一次维护工作简述
主要完成3项工作，分别是为已有自定义配方指定配方ID，隔离TFC金属板与Create金属板并重新建立关联，补充安山合金缺失的锌锭合成配方
## 1.为已有自定义配方指定配方ID
### 问题背景
`cbc_melting.js`中批量添加的熔炼配方采用自动生成的哈希 ID（如 `kubejs:shaped_abc123`），难以定位和管理，于是决定开展手动指定配方ID的工作
并非所有的配方都需要手动指定配方ID，如果在kjs脚本中一个物品在一个类型的配方中只有一种合成方式，那么KubeJS会自动生成`<命名空间>:<配方类型>/kjs/<产物名称>`格式的配方ID
所以仅针对`event_recipes.js`与`cbc_melting.js`中的部分配方进行了调整
### 解决方案
```javascript
// event_recipes.js
event.recipes.tfc.heating('minecraft:iron_nugget',1500).fluidOutput(Fluid.of('tfc:metal/cast_iron', 10))
.id('kubejs:tfc/heating/tfc/metal/cast_iron/minecraft/iron_nugget')// 指定配方ID

event.recipes.tfc.heating('minecraft:iron_block', 1500).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))// 与上一个配方拥有完全相同的产出和配方类型，不指定配方ID的话会使用哈希ID
.id('kubejs:tfc/heating/tfc/metal/cast_iron/minecraft/iron_block')// 指定配方ID

// cbc_melting.js
const inputKey = ingredientArray.map(ing => {
    if (ing.item) {return `item/${ing.item.replace(':', '/')}`}
    if (ing.tag) {return `tag/${ing.tag.replace(':', '/')}`}
    return 'unknown'
}).join('_')
const fluidId = resultFluid.get('id').getAsString().replace(':', '/')
const recipeId = `kubejs:createbigcannons/melting/${fluidId}/${inputKey}_${recipeCounter++}`
event.custom({/* cbc熔炼配方参数 */}).id(recipeId)
```
## 2.隔离TFC金属板与Create金属板并重新建立关联
### 问题背景
在当前客户端/服务端中，Create 模组的冲压板与 TFC 的锻造薄板存在成本不平衡问题：

| 冲压板物品 | 对应 TFC 薄板 | 获取方式 | 金属锭消耗 | 当前加热产出 |
|-----------|--------------|----------|------------|--------------|
| `create:copper_sheet` | `tfc:metal/sheet/copper` | Create 冲压（1铜锭） | 1 | 200mB ❌ |
| `tfc:metal/sheet/copper` | - | TFC 锻造（2铜锭） | 2 | 200mB |
| `create:brass_sheet` | `tfc:metal/sheet/brass` | Create 冲压（1黄铜锭） | 1 | 200mB ❌ |
| `tfc:metal/sheet/brass` | - | TFC 锻造（2黄铜锭） | 2 | 200mB |
| `create:iron_sheet` | `tfc:metal/sheet/wrought_iron` | Create 冲压（1铁锭） | 1 | ?（应产出铸铁液） |
| `create:golden_sheet` | `tfc:metal/sheet/gold` | Create 冲压（1金锭） | 1 | ? |
| `createdeco:zinc_sheet` | `tfc:metal/sheet/zinc` | Create 冲压（1锌锭） | 1 | ❌ 无加热配方 |

### TFC 金属温度参考

| 金属 | 近似温度 (°C) | 加热需求 |
|------|---------------|----------|
| 铜 | 1080 | heated |
| 黄铜 | 940 | heated |
| 铁 | 1538 | superheated |
| 金 | 1064 | heated |
| 锌 | 419 | heated |

### 铁的特殊处理

**重要**：铁板加热应产出铸铁液（`tfc:metal/cast_iron`），而非纯铁液。冲压铁板塑形应产出锻铁板（`tfc:metal/sheet/wrought_iron`）。

### 问题影响
Create 的金属板只需要一个金属锭就能冲压得到，但却能熔化出两个金属锭量的熔融金属，这意味着可以通过反复熔炼并冲压的方式**无限刷取金属锭**，严重破坏游戏经济平衡。

### 配方溯源

当前 TFC 模组中的加热（`kubejs:tfc/heating`）配方为了自动兼容科技模组的量产金属板手段，直接使用了如 `#c:sheets/<金属类型>` 的公共标签作为输入，这导致同样属于该标签的 Create 金属板被误判为 TFC 锻造板进行熔炼。

### 解决方案

**步骤一：隔离配方标签**

TFC 相关模组（`['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']`）不再自动识别 `#c:sheets/<金属类型>` 标签，而是创建独立的 `kubejs:tfc_single_sheets/<金属类型>` 标签，确保 Create 金属板不会被当成 TFC 锻造板去熔炼。
```javascript
// stamped_sheets_fix.js
singleSheetsMetalList.forEach(itemID => {
    const metalType = itemID.split('/')[2]
    event.replaceInput(
        {mod: mod},// TFC相关mod
        `#c:sheets/${metalType}`,// 公共的金属板标签
        `#kubejs:tfc_single_sheets/${metalType}`// 额外创建的独立TFC单金属板标签
    )
})
```

**步骤二：建立关联配方**

重新建立 Create 冲压板与 TFC 锻造板之间的合理转换途径：

```javascript
// stamped_sheets_fix.js
// 1. 冲压板熔化配方（产出100mB金属液，匹配1个金属锭的消耗）
// 1.1 TFC加热配方
event.recipes.tfc.heating(data.sheetItemID, data.temperature)
    .fluidOutput(Fluid.of(data.fluidID, data.fluidAmount))
    .id(tfcHeatingRecipeId)
// 1.2 Create Big Cannons熔化配方
event.custom({/* cbc熔炼配方参数 */}).id(recipeId)

// 2. 冲压板与锻造板双向转换
// 2.1 冲压板 -> 锻造板（2个冲压板 + 助焊剂）
compactingRecipe = event.recipes.create.compacting(data.tfcItemID,
    [Ingredient.of(`#${data.tagID}`, 2), Ingredient.of(`tfc:powder/flux`)])
if (data.temperature > 1080) {compactingRecipe.superheated()} 
else {compactingRecipe.heated()}
compactingRecipe.id(plateToSheetCompactingRecipeId)

// 2.2 锻造板 -> 冲压板（1个锻造板切为2个冲压板）
event.recipes.create.cutting(`2x ${data.sheetItemID}`, `${data.tfcItemID}`)
    .id(sheetToPlateCuttingRecipeId)
```

### 配置数据组织结构优化

为方便后续维护和调试，将`stamped_sheets_fix.js`中的配置数据（`otherModPlateMap` 和 `tfcMods`）从分散位置集中到脚本开头的"配置数据区域"：

```javascript
// stamped_sheets_fix.js - 配置数据区域（第18-38行）

// 其他模组冲压板映射表
// 用途：建立Create等模组的冲压板与TFC锻造板的对应关系
// 格式: c:plates/<材料> -> {item: 冲压板物品ID, temperature: 熔化温度(摄氏度)}
const otherModPlateMap = {
    'c:plates/copper':          {'item':'create:copper_sheet','temperature':1080},
    'c:plates/wrought_iron':    {'item':'create:iron_sheet','temperature':1538},
    'c:plates/gold':            {'item':'create:golden_sheet','temperature':1064},
    'c:plates/brass':           {'item':'create:brass_sheet','temperature':940},
    'c:plates/zinc':            {'item':'createdeco:zinc_sheet','temperature':419}
}

// TFC及其附属模组列表
// 这些模组的配方如果使用了c:sheets/*标签，都需要替换
const tfcMods = ['tfc','firmalife','tfcastikorcarts','tfc_items','tfcfertigation']
```

**优化效果**：配置数据集中在脚本开头，便于快速定位和修改；无需处理文件加载、路径、全局对象等复杂问题。

## 3. 安山合金锌锭合成修复
### 问题背景
在当前客户端/服务端中，Create 模组的安山合金只能使用锻铁锭进行合成
```javascript
// event_recipes.js
event.shapeless(Item.of('create:andesite_alloy', 8), [
    '#c:cobblestones',
    '#c:ingots/iron'
])
```
但根据Create模组中已有的配方，锌应该能完全替代铁去参与合成
### 解决方案
```javascript
// event_recipes.js
  // 配方1：铁锭版本
  event.shapeless(Item.of('create:andesite_alloy', 8), [
      '#c:cobblestones',
      '#c:ingots/iron'
  ]).id('kubejs:create/andesite_alloy_iron')
  // 配方2：锌锭版本
  event.shapeless(Item.of('create:andesite_alloy', 8), [
      '#c:cobblestones',
      '#c:ingots/zinc'
  ]).id('kubejs:create/andesite_alloy_zinc')
```

---

## 总结

本次维护工作共完成 **3 项核心任务**：

| 序号 | 工作内容 | 核心目标 | 涉及文件 |
|------|----------|----------|----------|
| 1 | 配方ID规范化 | 解决自动生成的哈希ID难以定位和管理的问题 | `event_recipes.js`、`cbc_melting.js` |
| 2 | TFC与Create金属板隔离 | 修复金属锭刷取漏洞，恢复游戏经济平衡 | `stamped_sheets_fix.js` |
| 3 | 安山合金锌锭合成 | 补充缺失的合成配方，完善游戏体验 | `event_recipes.js` |

**技术亮点**：
- 通过标签替换机制实现了模组间物品的隔离，不影响其他模组的正常运作
- 建立了合理的双向转换配方，既保证平衡性又保持玩法灵活性
- 优化了配置数据结构，提高了脚本的可维护性和可调试性