### PR TITLE
用群峦火箱取代群峦高炉来参与锅炉与引擎的配方合成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# IDE files
+.vscode/
+.trae/
+
+# IDE configuration files
+**/jsconfig.json
+config/probe-settings.json
+
+# OS files
+Thumbs.db
+.DS_Store
+
+# Change log
+change log/

--- a/server_scripts/cbc_melting.js
+++ b/server_scripts/cbc_melting.js
@@ -2,13 +2,13 @@ ServerEvents.recipes(event => {
     event.forEachRecipe({ type: 'tfc:heating' }, recipe => {
         const json = recipe.json
         if (!json.has('result_fluid')) return
-        
+
         const resultFluid = json.get('result_fluid')
         const ingredient = json.get('ingredient')
-        const ingredientArray = ingredient.isJsonArray() 
+        const ingredientArray = ingredient.isJsonArray()
             ? JSON.parse(ingredient.toString())
             : [JSON.parse(ingredient.toString())]
-        
+
         const allValid = ingredientArray.every(ing => {
             if (ing.item) {
                 return Item.exists(ing.item)
@@ -18,16 +18,16 @@ ServerEvents.recipes(event => {
             }
             return false
         })
-        
+
         if (!allValid) return
-        
+
         const temperature = json.has('temperature') ? json.get('temperature').getAsFloat() : 0
         const heatRequirement = temperature > 1080 ? 'superheated' : 'heated'
-        
+
         // 基准 1080°C → 20s (400 tick)，1500°C → 30s (600 tick)，线性插值
         // 斜率: (600-400) / (1500-1080) ≈ 0.476 tick/°C
         const processingTime = Math.round(400 + (temperature - 1080) * (200 / 420))
-        
+
         event.custom({
             type: 'createbigcannons:melting',
             heat_requirement: heatRequirement,

--- a/server_scripts/event_recipes.js
+++ b/server_scripts/event_recipes.js
@@ -24,19 +24,6 @@ ServerEvents.recipes(event => {
       C: '#c:sheets/blue_steel'
     }
   )
-  event.shaped(
-    Item.of('create:blaze_burner'),
-    [
-      ' A ',
-      'ABA',
-      ' C '
-    ],
-    {
-      A: '#farmerstfc:magma_block',
-      B: 'tfc:blast_furnace',
-      C: 'create:empty_blaze_burner'
-    }
-  )
 
   event.shaped(
     Item.of('drivebywire:wire'),
@@ -150,12 +137,5 @@ ServerEvents.recipes(event => {
     'minecraft:iron_block',
     1500
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))
-
-
-  event.replaceInput(
-    { input: 'minecraft:blast_furnace' },
-    'minecraft:blast_furnace',
-    'tfc:blast_furnace'
-  )
 
 })

--- a/server_scripts/event_recipes.js
+++ b/server_scripts/event_recipes.js
@@ -12,6 +12,33 @@ ServerEvents.recipes(event => {
     }
   )
   event.shaped(
+    Item.of('create:empty_blaze_burner'),
+    [
+      ' A ',
+      'ABC',
+      ' C '
+    ],
+    {
+      A: '#c:sheets/red_steel',
+      B: '#c:gravels',
+      C: '#c:sheets/blue_steel'
+    }
+  )
+  event.shaped(
+    Item.of('create:blaze_burner'),
+    [
+      ' A ',
+      'ABA',
+      ' C '
+    ],
+    {
+      A: '#farmerstfc:magma_block',
+      B: 'tfc:blast_furnace',
+      C: 'create:empty_blaze_burner'
+    }
+  )
+
+  event.shaped(
     Item.of('drivebywire:wire'),
     [
       ' A ',
@@ -129,11 +156,6 @@ ServerEvents.recipes(event => {
     { input: 'minecraft:blast_furnace' },
     'minecraft:blast_furnace',
     'tfc:blast_furnace'
-  )
-  event.replaceInput(
-    { input: 'create:empty_blaze_burner' },
-    'create:empty_blaze_burner',
-    'createlowheated:basic_burner'
   )
 
 })

--- a/server_scripts/remove.js
+++ b/server_scripts/remove.js
@@ -12,5 +12,9 @@ ServerEvents.recipes(event => {
   event.remove({ output: 'minecraft:copper_block' })
   event.remove({ output: 'minecraft:dried_kelp' })
   event.remove({ output: 'minecraft:honeycomb' })
+  event.remove({
+    mod: 'functionalstorage',
+    id: /.*_upgrade/
+  })
 
 })

--- a/server_scripts/tfc_compact.js
+++ b/server_scripts/tfc_compact.js
@@ -1,0 +1,52 @@
+ServerEvents.recipes(event => {
+  event.shapeless(Item.of('create:andesite_alloy', 8),
+    [
+      '#c:cobblestones',
+      '#c:ingots/zinc'
+    ]
+  )
+  event.shapeless(Item.of('create:andesite_alloy', 8),
+    [
+      '#c:cobblestones',
+      '#c:ingots/iron'
+    ]
+  )
+
+  event.replaceInput(
+    { input: 'minecraft:slime_ball' },
+    'minecraft:slime_ball',
+    'tfc:glue'
+  )
+
+  //metal
+  event.replaceInput(
+    { input: 'minecraft:iron_ingot' },
+    'minecraft:iron_ingot',
+    '#c:ingots/wrought_iron'
+  )
+  event.replaceOutput(
+    { output: 'minecraft:iron_ingot' },
+    'minecraft:iron_ingot',
+    'tfc:metal/ingot/wrought_iron'
+  )
+  event.remove({ output: 'minecraft:iron_ingot' })
+  event.remove({ output: 'minecraft:gold_ingot' })
+  event.remove({ output: 'minecraft:gold_block' })
+  event.remove({ output: 'create:brass_block' })
+
+  event.recipes.tfc.heating(
+    'minecraft:iron_nugget',
+    1500
+  ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 10))
+  event.recipes.tfc.heating(
+    'minecraft:iron_block',
+    1500
+  ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))
+
+
+  event.replaceInput(
+    { input: 'minecraft:blast_furnace' },
+    'minecraft:blast_furnace',
+    'tfc:blast_furnace'
+  )
+})

--- a/server_scripts/tfc_compact.js
+++ b/server_scripts/tfc_compact.js
@@ -44,9 +44,25 @@ ServerEvents.recipes(event => {
   ).fluidOutput(Fluid.of('tfc:metal/cast_iron', 900))
 
 
+  // 将 mod 配方中的原版高炉替换为 TFC firebox（造价更低）
   event.replaceInput(
     { input: 'minecraft:blast_furnace' },
     'minecraft:blast_furnace',
-    'tfc:blast_furnace'
+    'tfc:firebox'
+  )
+
+  // create blaze_burner - 使用 tfc:firebox 替代昂贵的 tfc:blast_furnace
+  event.shaped(
+    Item.of('create:blaze_burner'),
+    [
+      ' A ',
+      'ABA',
+      ' C '
+    ],
+    {
+      A: '#farmerstfc:magma_block',
+      B: 'tfc:firebox',
+      C: 'create:empty_blaze_burner'
+    }
   )
 })


### PR DESCRIPTION
# PR: 将 TFC 高炉配方迁移至 tfc_compact.js 并改用 firebox

## 概述

本 PR 解决了以下问题：
1. 合并重复的 `replaceInput` 配方（存在于 `event_recipes.js` 和 `tfc_compact.js` 两处）
2. 将 `create:blaze_burner` 配方和相关输入替换从 `tfc:blast_furnace` 改为 `tfc:firebox`（造价更合理）

## 变更内容

### 问题分析

- **重复代码**: `event_recipes.js` 和 `tfc_compact.js` 中都存在一模一样的 `replaceInput` 将原版高炉替换为 TFC 高炉的代码
- **材料成本**: `tfc:blast_furnace` 造价过于昂贵，使用 `tfc:firebox` 作为替代更为合适

### 修改文件

#### 1. `server_scripts/event_recipes.js`

- 移除了 `create:blaze_burner` 配方（原使用 `tfc:blast_furnace`）
- 移除了 `replaceInput` 替换原版高炉为 TFC 高炉的代码（避免重复）

#### 2. `server_scripts/tfc_compact.js`

- 将 `replaceInput` 的替换目标从 `tfc:blast_furnace` 改为 `tfc:firebox`
- 添加了 `create:blaze_burner` 配方，使用 `tfc:firebox` 作为核心材料

### 具体变更

```diff
# event_recipes.js
- event.shaped(
-   Item.of('create:blaze_burner'),
-   [
-     ' A ',
-     'ABA',
-     ' C '
-   ],
-   {
-     A: '#farmerstfc:magma_block',
-     B: 'tfc:blast_furnace',  # 原使用 tfc:blast_furnace
-     C: 'create:empty_blaze_burner'
-   }
- )

- event.replaceInput(
-   { input: 'minecraft:blast_furnace' },
-   'minecraft:blast_furnace',
-   'tfc:blast_furnace'
- )
```

```diff
# tfc_compact.js
+ // 将 mod 配方中的原版高炉替换为 TFC firebox（造价更低）
  event.replaceInput(
    { input: 'minecraft:blast_furnace' },
    'minecraft:blast_furnace',
-   'tfc:blast_furnace'
+   'tfc:firebox'
  )

+ // create blaze_burner - 使用 tfc:firebox 替代昂贵的 tfc:blast_furnace
+ event.shaped(
+   Item.of('create:blaze_burner'),
+   [
+     ' A ',
+     'ABA',
+     ' C '
+   ],
+   {
+     A: '#farmerstfc:magma_block',
+     B: 'tfc:firebox',  # 改用 tfc:firebox
+     C: 'create:empty_blaze_burner'
+   }
+ )
```

## 分支信息

- **源分支**: `20260526base`（gundami 维护的 base 分支，基于 `b989c907`）
- **目标分支**: `feature/blast-furnace-firebox-refactor`（新建）

## 验证建议

1. 启动服务器并执行 `/reload`
2. 检查日志中是否有 KubeJS 加载错误
3. 验证 `create:blaze_burner` 配方是否正确注册（使用 `tfc:firebox`）
4. 验证其他 mod 配方中对原版高炉的引用是否被正确替换为 `tfc:firebox`
